### PR TITLE
Set Content-Length header when posting a form

### DIFF
--- a/gluahttp.go
+++ b/gluahttp.go
@@ -166,6 +166,7 @@ func (h *httpModule) doRequest(L *lua.LState, method string, url string, options
 
 		case lua.LString:
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.ContentLength = int64(len(reqForm.String()))
 			req.Body = ioutil.NopCloser(strings.NewReader(reqForm.String()))
 			break
 		}


### PR DESCRIPTION
Some servers will reject a POST when there is no content-length header (or if it is inaccurate). This header cannot be set from the `header` options within lua (I tracked "why" down when I committed this, but have since forgotten).