### PR TITLE
Fix "string expected, got string" error

### DIFF
--- a/gluahttp_test.go
+++ b/gluahttp_test.go
@@ -316,6 +316,20 @@ func TestResponseBodySize(t *testing.T) {
 	}
 }
 
+func TestResponseBody(t *testing.T) {
+	listener, _ := net.Listen("tcp", "127.0.0.1:0")
+	setupServer(listener)
+
+	if err := evalLua(t, `
+		local http = require("http")
+		response, error = http.get("http://`+listener.Addr().String()+`/")
+
+		assert_equal("Requested XXX / with query \"\"", string.gsub(response.body, "GET", "XXX"))
+	`); err != nil {
+		t.Errorf("Failed to evaluate script: %s", err)
+	}
+}
+
 func TestResponseUrl(t *testing.T) {
 	listener, _ := net.Listen("tcp", "127.0.0.1:0")
 	setupServer(listener)

--- a/httpresponsetype.go
+++ b/httpresponsetype.go
@@ -88,7 +88,7 @@ func httpResponseUrl(res *luaHttpResponse, L *lua.LState) int {
 }
 
 func httpResponseBody(res *luaHttpResponse, L *lua.LState) int {
-	L.Push(&res.body)
+	L.Push(res.body)
 	return 1
 }
 


### PR DESCRIPTION
*string is different than just string. Buildin functions expect
normal strings. Right now using body with a function that expects
a string, such as gsub, results in:
`bad argument #1 to gsub (string expected, got string)`.