### PR TITLE
Fix #15 close the body on success

### DIFF
--- a/gluahttp.go
+++ b/gluahttp.go
@@ -4,7 +4,6 @@ import "github.com/yuin/gopher-lua"
 import "net/http"
 import "fmt"
 import "errors"
-import "io"
 import "io/ioutil"
 import "strings"
 
@@ -176,13 +175,10 @@ func (h *httpModule) doRequest(L *lua.LState, method string, url string, options
 	res, err := h.client.Do(req)
 
 	if err != nil {
-		if res != nil {
-			io.Copy(ioutil.Discard, res.Body)
-			defer res.Body.Close()
-		}
-
 		return nil, err
 	}
+
+	defer res.Body.Close()
 
 	// TODO: Add a way to discard body
 


### PR DESCRIPTION
Also, we never have to close the body on error. From the http.Do docs:

    On error, any Response can be ignored. A non-nil Response with a
    non-nil error only occurs when CheckRedirect fails, and even then
    the returned Response.Body is already closed.