### PR TITLE
add access jsonBody in http.Post()

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ func main() {
 | query   | String | URL encoded query params |
 | cookies | Table  | Additional cookies to send with the request |
 | form    | String | URL encoded request body. This will also set the `Content-Type` header to `application/x-www-form-urlencoded` |
+| jsonBody| String | jsonStr in http body |
 | headers | Table  | Additional headers to send with the request |
 
 **Returns**

--- a/gluahttp.go
+++ b/gluahttp.go
@@ -170,8 +170,19 @@ func (h *httpModule) doRequest(L *lua.LState, method string, url string, options
 			req.Body = ioutil.NopCloser(strings.NewReader(body))
 			break
 		}
-	}
 
+		switch reqJSONBody := options.RawGet(lua.LString("jsonBody")).(type) {
+		case *lua.LNilType:
+			break
+
+		case lua.LString:
+			body := reqJSONBody.String()
+			req.ContentLength = int64(len(body))
+			req.Header.Set("Content-Type", "application/json;charset=utf-8")
+			req.Body = ioutil.NopCloser(strings.NewReader(body))
+			break
+		}
+	}
 	res, err := h.client.Do(req)
 
 	if err != nil {

--- a/gluahttp_test.go
+++ b/gluahttp_test.go
@@ -224,11 +224,41 @@ func TestPost(t *testing.T) {
 			form="username=bob&password=secret"
 		})
 
+		print(response['body'])
+
 		assert_equal(
 			'Requested POST / with query ""' ..
 			'Content-Type: application/x-www-form-urlencoded' ..
 			'Content-Length: 28' ..
 			'Body: username=bob&password=secret', response['body'])
+	`); err != nil {
+		t.Errorf("Failed to evaluate script: %s", err)
+	}
+}
+
+func TestPostJSON(t *testing.T) {
+	listener, _ := net.Listen("tcp", "127.0.0.1:0")
+	setupServer(listener)
+
+	if err := evalLua(t, `
+		local http = require("http")
+		local jsonStr = "{\"username\":\"bob\",\"password\":\"secret\"}"
+		response, error = http.post("http://`+listener.Addr().String()+`", {
+				headers={
+            		Accept="application/json",
+            		Authorization="auth"
+        		},
+				jsonBody=jsonStr
+			})
+
+		print(type(response.body))
+		print(response['body'])
+
+		assert_equal(
+			'Requested POST / with query ""' ..
+			'Content-Type: application/json;charset=utf-8' ..
+			'Content-Length: 38' ..
+			'Body: {"username":"bob","password":"secret"}', response['body'])
 	`); err != nil {
 		t.Errorf("Failed to evaluate script: %s", err)
 	}


### PR DESCRIPTION
Hi, many thanks for your excellent work in helpfull gluahttp. It's my first pr... excited!

It adds access to jsonBody(type: string) in http.Post(), so we can post a json object in string.