### PR TITLE
add func NewHttpModuleWithDo, to allow switching between multiple clients per-request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 
 go:
-  - 1.4
-  - 1.5
-  - 1.6
+  - "1.8"
+  - "1.9"
+  - "1.10"
 
 install:
   - go get github.com/yuin/gopher-lua

--- a/gluahttp.go
+++ b/gluahttp.go
@@ -9,6 +9,8 @@ import "strings"
 
 type httpModule struct {
 	client *http.Client
+
+	do func(req *http.Request) (*http.Response, error)
 }
 
 type empty struct{}
@@ -16,6 +18,12 @@ type empty struct{}
 func NewHttpModule(client *http.Client) *httpModule {
 	return &httpModule{
 		client: client,
+	}
+}
+
+func NewHttpModuleWithDo(do func(req *http.Request) (*http.Response, error)) *httpModule {
+	return &httpModule{
+		do: do,
 	}
 }
 
@@ -175,7 +183,13 @@ func (h *httpModule) doRequest(L *lua.LState, method string, url string, options
 		}
 	}
 
-	res, err := h.client.Do(req)
+	var res *http.Response
+
+	if h.do != nil {
+		res, err = h.do(req)
+	} else {
+		res, err = h.client.Do(req)
+	}
 
 	if err != nil {
 		return nil, err

--- a/gluahttp_test.go
+++ b/gluahttp_test.go
@@ -46,10 +46,18 @@ func TestRequestBatch(t *testing.T) {
 			1
 		})
 
-		assert_equal(nil, errors[1])
-		assert_equal(nil, errors[2])
-		assert_contains('unsupported protocol scheme ""', errors[3])
-		assert_equal('Request must be a table', errors[4])
+		-- the requests are send asynchronously, so the errors might not be in the same order
+		-- if we don't sort, the test will be flaky
+		local errorStrings = {}
+		for _, err in pairs(errors) do
+			table.insert(errorStrings, tostring(err))
+		end
+		table.sort(errorStrings)
+
+		assert_contains('Post : unsupported protocol scheme ""', errorStrings[1])
+		assert_equal('Request must be a table', errorStrings[2])
+		assert_equal(nil, errorStrings[3])
+		assert_equal(nil, errorStrings[4])
 
 		assert_equal('Requested GET / with query "page=1"', responses[1]["body"])
 		assert_equal('Cookie set!', responses[2]["body"])


### PR DESCRIPTION
We needed to switch between multiple http clients based on the URL/Domain.

So I added `NewHttpModuleWithDo`, that gets the `client.Do` function instead of http client.
And it will be used later if it's non-nil