### PR TITLE
Add Basic auth to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ func main() {
 | cookies | Table  | Additional cookies to send with the request |
 | headers | Table  | Additional headers to send with the request |
 | timeout | Number/String | Request timeout. Number of seconds or String such as "1h" |
+| auth    | Table  | Username and password for HTTP basic auth. Table keys are *user* for username, *pass* for passwod. `auth={user="user", pass="pass"}` |
 
 **Returns**
 
@@ -91,6 +92,7 @@ func main() {
 | cookies | Table  | Additional cookies to send with the request |
 | headers | Table  | Additional headers to send with the request |
 | timeout | Number/String | Request timeout. Number of seconds or String such as "1h" |
+| auth    | Table  | Username and password for HTTP basic auth. Table keys are *user* for username, *pass* for passwod. `auth={user="user", pass="pass"}` |
 
 **Returns**
 
@@ -113,6 +115,7 @@ func main() {
 | cookies | Table  | Additional cookies to send with the request |
 | headers | Table  | Additional headers to send with the request |
 | timeout | Number/String | Request timeout. Number of seconds or String such as "1h" |
+| auth    | Table  | Username and password for HTTP basic auth. Table keys are *user* for username, *pass* for passwod. `auth={user="user", pass="pass"}` |
 
 **Returns**
 
@@ -137,6 +140,7 @@ func main() {
 | form    | String | Deprecated. URL encoded request body. This will also set the `Content-Type` header to `application/x-www-form-urlencoded` |
 | headers | Table  | Additional headers to send with the request |
 | timeout | Number/String | Request timeout. Number of seconds or String such as "1h" |
+| auth    | Table  | Username and password for HTTP basic auth. Table keys are *user* for username, *pass* for passwod. `auth={user="user", pass="pass"}` |
 
 **Returns**
 
@@ -161,6 +165,7 @@ func main() {
 | form    | String | Deprecated. URL encoded request body. This will also set the `Content-Type` header to `application/x-www-form-urlencoded` |
 | headers | Table  | Additional headers to send with the request |
 | timeout | Number/String | Request timeout. Number of seconds or String such as "1h" |
+| auth    | Table  | Username and password for HTTP basic auth. Table keys are *user* for username, *pass* for passwod. `auth={user="user", pass="pass"}` |
 
 **Returns**
 
@@ -185,6 +190,7 @@ func main() {
 | form    | String | Deprecated. URL encoded request body. This will also set the `Content-Type` header to `application/x-www-form-urlencoded` |
 | headers | Table  | Additional headers to send with the request |
 | timeout | Number/String | Request timeout. Number of seconds or String such as "1h" |
+| auth    | Table  | Username and password for HTTP basic auth. Table keys are *user* for username, *pass* for passwod. `auth={user="user", pass="pass"}` |
 
 **Returns**
 
@@ -210,7 +216,7 @@ func main() {
 | form    | String | Deprecated. URL encoded request body. This will also set the `Content-Type` header to `application/x-www-form-urlencoded` |
 | headers | Table  | Additional headers to send with the request |
 | timeout | Number/String | Request timeout. Number of seconds or String such as "1h" |
-| auth    | Table  | Basic auth for request. Set user and pass keys. |
+| auth    | Table  | Username and password for HTTP basic auth. Table keys are *user* for username, *pass* for passwod. `auth={user="user", pass="pass"}` |
 
 **Returns**
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ func main() {
 | form    | String | Deprecated. URL encoded request body. This will also set the `Content-Type` header to `application/x-www-form-urlencoded` |
 | headers | Table  | Additional headers to send with the request |
 | timeout | Number/String | Request timeout. Number of seconds or String such as "1h" |
+| auth    | Table  | Basic auth for request. Set user and pass keys. |
 
 **Returns**
 

--- a/gluahttp.go
+++ b/gluahttp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/yuin/gopher-lua"
 	"io/ioutil"
 	"net/http"
 	"strings"


### PR DESCRIPTION
Adds a new key to options named auth. Its value is a table with two keys: user and pass. If all keys set, call of SetBasicAuth is performed on request.